### PR TITLE
Fiz algumas modificações no dojotools

### DIFF
--- a/dojotools
+++ b/dojotools
@@ -31,8 +31,80 @@ from optparse import OptionParser
 import gtk
 import gobject
 import arduino
-
+import threading
+import datetime
 from ui import UserInterface
+
+
+
+class RunThread (threading.Thread):
+    """Thread class with a stop() method. The thread itself has to check
+    regularly for the stopped() condition."""
+
+    def __init__ (self, test_cmd,  monitor):
+        super(RunThread, self).__init__()
+        self._stop = threading.Event()
+        self.test_cmd = test_cmd
+        self.directory = monitor.directory
+        self.arduino = monitor.arduino
+        self.ui = monitor.ui
+        self.start_time = '%02d:%02d:%02d' % (
+                (datetime.datetime.now().hour),
+                (datetime.datetime.now().minute),
+                (datetime.datetime.now().second),
+            )
+        self.process = None
+        
+    def run(self):
+        """
+        runs a command and waits for it to finish
+        """
+        self.ui.kill_item.set_label("Matar "+self.__repr__())
+        self.process = subprocess.Popen(
+            self.test_cmd,
+            shell = True,
+            cwd = self.directory,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.PIPE,
+        )
+
+        output = self.process.stdout.read()
+        output += self.process.stderr.read()
+        status = self.process.wait()
+        try:
+            if self.arduino:
+                arduino.send_message(status)
+        except:
+            print 'Algum erro de comunicação com o Arduino ocorreu!'
+
+        self.ui.kill_item.set_label(u"Nenhum projeto em execução")
+        self.stop()
+        self.ui.show_command_results(status, output)
+        return output
+        
+        
+    def stop (self):
+        if not self.ui.kill_item.get_label() == u"Nenhum projeto em execução":
+            self.ui.show_command_results(True, u"Execução interrompida")
+        self.ui.kill_item.set_label(u"Nenhum projeto em execução")
+        try:
+            self.process.stdout.close() 
+            self.process.stderr.close() 
+            self.process.terminate()   
+              
+        except:
+            pass
+        
+
+        self._stop.set()
+        self._Thread__stop()
+        #
+
+    def stopped (self):
+        return self._stop.isSet()
+        
+    def __repr__(self):
+        return self.start_time+" - "+self.test_cmd.split()[-1]
 
 class Timer(object):
 
@@ -61,7 +133,7 @@ class Timer(object):
 
 class Monitor(object):
 
-    def __init__(self, ui, directory, commands, patterns_file, commit=False, arduino=False):
+    def __init__(self, ui, directory, commands, patterns_file, commit=False, arduino=False, use_thread=False):
         """
         'directory' is the directory to be watched for changes.
 
@@ -81,6 +153,7 @@ class Monitor(object):
         self.ui = ui
         self.commit = commit
         self.arduino = arduino
+        self.use_thread = use_thread
 
         gobject.timeout_add(1000, self.check)
 
@@ -139,7 +212,25 @@ class Monitor(object):
 
     def run_command(self, test_cmd):
         """
-        As the name says, runs a command and waits for it to finish
+        As the name says, runs a command 
+        """
+        if self.use_thread:
+            self._run_by_thread(test_cmd)
+        else:
+            self._normal_run(test_cmd)
+
+        
+    def _run_by_thread(self, test_cmd):
+        """
+        Runs command in a thread without waiting for it to finish
+        """
+        thread = RunThread(test_cmd, self)
+        thread.start()
+        self.ui.thread = thread
+        
+    def _normal_run(self, test_cmd):
+        """
+        Runs a command and waits for it to finish"
         """
         process = subprocess.Popen(
             test_cmd,
@@ -157,9 +248,8 @@ class Monitor(object):
                 arduino.send_message(status)
         except:
             print 'Algum erro de comunicação com o Arduino ocorreu!'
-
-        self.ui.show_command_results(status, output)
-
+        self.ui.show_command_results(status, output)    
+        
     def check(self):
         """
         Monitor self.directory for changes, ignoring files matching any item
@@ -257,6 +347,17 @@ def parse_options():
         ),
         default = False,
     )
+    
+    parser.add_option(
+        '-m',
+        '--multithread',
+        action = 'store_true',
+        dest = 'use_thread',
+        help = (
+            'If this flag is used the program will run in a thread'
+        ),
+        default = False,
+    )
     return parser.parse_args()
 
 
@@ -276,7 +377,7 @@ if __name__ == '__main__':
         print 'press ^C to quit'
 
         timer = Timer(options.round_time)
-        ui = UserInterface(timer)
+        ui = UserInterface(timer, options.use_thread)
         monitor = Monitor(
             ui = ui,
             directory = options.directory,
@@ -284,10 +385,13 @@ if __name__ == '__main__':
             patterns_file = options.patterns_file,
             commit = options.commit,
             arduino = options.arduino,
+            use_thread = options.use_thread,
         )
 
         gtk.main()
 
     except KeyboardInterrupt:
         print '\nleaving...'
+        if options.use_thread:
+            ui.thread.stop()
         sys.exit(0)

--- a/dojotools
+++ b/dojotools
@@ -59,7 +59,7 @@ class RunThread (threading.Thread):
         """
         runs a command and waits for it to finish
         """
-        self.ui.kill_item.set_label("Matar "+self.__repr__())
+        self.ui.set_kill_label("Matar "+self.__repr__())
         self.process = subprocess.Popen(
             self.test_cmd,
             shell = True,
@@ -76,17 +76,19 @@ class RunThread (threading.Thread):
                 arduino.send_message(status)
         except:
             print 'Algum erro de comunicação com o Arduino ocorreu!'
-
-        self.ui.kill_item.set_label(u"Nenhum projeto em execução")
+        
+        self.ui.set_kill_label()
         self.stop()
         self.ui.show_command_results(status, output)
         return output
         
         
     def stop (self):
+        
         if not self.ui.kill_item.get_label() == u"Nenhum projeto em execução":
             self.ui.show_command_results(True, u"Execução interrompida")
-        self.ui.kill_item.set_label(u"Nenhum projeto em execução")
+        self.ui.set_kill_label()
+        
         try:
             self.process.stdout.close() 
             self.process.stderr.close() 

--- a/dojotools
+++ b/dojotools
@@ -136,7 +136,7 @@ class Timer(object):
 
 class Monitor(object):
 
-    def __init__(self, ui, directory, commands, patterns_file, commit=False, arduino=False, use_thread=False):
+    def __init__(self, ui, directory, commands, patterns_file, commit=False, arduino=False, use_thread=False, before=""):
         """
         'directory' is the directory to be watched for changes.
 
@@ -157,6 +157,7 @@ class Monitor(object):
         self.commit = commit
         self.arduino = arduino
         self.use_thread = use_thread
+        self.before = before
 
         gobject.timeout_add(1000, self.check)
 
@@ -213,10 +214,16 @@ class Monitor(object):
                     lang.GIT_ERROR2)
             raise OSError(error)
 
+
+
+
     def run_command(self, test_cmd):
         """
         As the name says, runs a command 
         """
+        if self.before:
+            self._normal_run(self.before, before_command=True)
+            
         if self.use_thread:
             self._run_by_thread(test_cmd)
         else:
@@ -231,7 +238,7 @@ class Monitor(object):
         thread.start()
         self.ui.thread = thread
         
-    def _normal_run(self, test_cmd):
+    def _normal_run(self, test_cmd, before_command=False):
         """
         Runs a command and waits for it to finish"
         """
@@ -251,7 +258,10 @@ class Monitor(object):
                 arduino.send_message(status)
         except:
             print lang.ARDUINO_ERROR
-        self.ui.show_command_results(status, output)    
+        if not before_command:
+            self.ui.show_command_results(status, output)
+        else:
+            sys.stdout.write(output)
         
     def check(self):
         """
@@ -347,6 +357,16 @@ def parse_options():
         help = lang.MULTITHREAD_HELP,
         default = False,
     )
+    
+    parser.add_option(
+        '-b',
+        '--before',
+        action = 'store',
+        type = 'string',
+        dest = 'before_command',
+        help = lang.BEFORE_HELP,
+        default = ""
+    )
     return parser.parse_args()
 
 
@@ -375,6 +395,7 @@ if __name__ == '__main__':
             commit = options.commit,
             arduino = options.arduino,
             use_thread = options.use_thread,
+            before = options.before_command,
         )
 
         gtk.main()

--- a/dojotools
+++ b/dojotools
@@ -33,13 +33,15 @@ import gobject
 import arduino
 import threading
 import datetime
+import lang
 from ui import UserInterface
 
 
 
+
+
 class RunThread (threading.Thread):
-    """Thread class with a stop() method. The thread itself has to check
-    regularly for the stopped() condition."""
+    """Thread class to run and terminate commands."""
 
     def __init__ (self, test_cmd,  monitor):
         super(RunThread, self).__init__()
@@ -59,7 +61,7 @@ class RunThread (threading.Thread):
         """
         runs a command and waits for it to finish
         """
-        self.ui.set_kill_label("Matar "+self.__repr__())
+        self.ui.set_kill_label(lang.KILL % (self.__repr__()))
         self.process = subprocess.Popen(
             self.test_cmd,
             shell = True,
@@ -75,7 +77,7 @@ class RunThread (threading.Thread):
             if self.arduino:
                 arduino.send_message(status)
         except:
-            print 'Algum erro de comunicação com o Arduino ocorreu!'
+            print lang.ARDUINO_ERROR
         
         self.ui.set_kill_label()
         self.stop()
@@ -84,9 +86,9 @@ class RunThread (threading.Thread):
         
         
     def stop (self):
-        
-        if not self.ui.kill_item.get_label() == u"Nenhum projeto em execução":
-            self.ui.show_command_results(True, u"Execução interrompida")
+        """Stop thread and terminate running command"""
+        if not self.ui.kill_item.get_label() == lang.NO_RUNNING:
+            self.ui.show_command_results(True, lang.INTERRUPTED_EXECUTION)
         self.ui.set_kill_label()
         
         try:
@@ -97,10 +99,9 @@ class RunThread (threading.Thread):
         except:
             pass
         
-
         self._stop.set()
         self._Thread__stop()
-        #
+
 
     def stopped (self):
         return self._stop.isSet()
@@ -173,7 +174,7 @@ class Monitor(object):
                 patterns = [pattern.strip() for pattern in  f.readlines()]
         except IOError:
             sys.stdout.write(
-                'Could not find %s. Patterns will not be ignored\n'
+                lang.PATTERNS_NOT_FOUND
                 % patterns_file
             )
             patterns = []
@@ -208,8 +209,8 @@ class Monitor(object):
 
         #if git returns 128 it means 'command not found' or 'not a git repo'
         if process.wait() == 128:
-            error = ('Impossible to commit to repository. '
-                    'Make sure git is installed an this is a valid repository')
+            error = (lang.GIT_ERROR1+
+                    lang.GIT_ERROR2)
             raise OSError(error)
 
     def run_command(self, test_cmd):
@@ -249,7 +250,7 @@ class Monitor(object):
             if self.arduino:
                 arduino.send_message(status)
         except:
-            print 'Algum erro de comunicação com o Arduino ocorreu!'
+            print lang.ARDUINO_ERROR
         self.ui.show_command_results(status, output)    
         
     def check(self):
@@ -287,22 +288,14 @@ class Monitor(object):
 
 def parse_options():
     usage = "%prog [OPTIONS] COMMAND ..."
-    description = """
-        %prog watches a directory for changes. As soon as there are any changes
-        to the files being watched, it runs the commands specified as positional
-        arguments. You can specify as many commands as you wish, but don't forget
-        to use quotes if you command has spaces in it.
-    """.replace('  ', '')
+    description = lang.DESCRIPTION
     parser = OptionParser(usage, description=description)
     parser.add_option(
         '-c',
         '--commit',
         action='store_true',
         dest = 'commit',
-        help = (
-            'if this flag is used, a git commit will '
-            'be issued whenever the files change'
-        ),
+        help = lang.GIT_HELP,
         default = False,
     )
     parser.add_option(
@@ -311,7 +304,7 @@ def parse_options():
         action = 'store',
         type = 'string',
         dest = 'directory',
-        help = 'Watch DIRECTORY',
+        help = lang.DIRECTORY_HELP,
         metavar = 'DIRECTORY',
         default = os.path.abspath(os.path.curdir)
     )
@@ -322,9 +315,7 @@ def parse_options():
         action = 'store',
         type = 'string',
         dest = 'patterns_file',
-        help = (
-            'Defines the file with patterns to ignore. '
-        ),
+        help = lang.PATTERNS_HELP,
         metavar = 'PATTERNS_FILE',
         default = None,
     )
@@ -335,7 +326,7 @@ def parse_options():
         action = 'store',
         type = 'int',
         dest = 'round_time',
-        help = 'Define the time of each round',
+        help = lang.TIME_HELP,
         default = 300
     )
 
@@ -344,9 +335,7 @@ def parse_options():
         '--arduino',
         action = 'store_true',
         dest = 'arduino',
-        help = (
-            'If this flag is used an interface with Arduino will be used'
-        ),
+        help = lang.ARDUINO_HELP,
         default = False,
     )
     
@@ -355,9 +344,7 @@ def parse_options():
         '--multithread',
         action = 'store_true',
         dest = 'use_thread',
-        help = (
-            'If this flag is used the program will run in a thread'
-        ),
+        help = lang.MULTITHREAD_HELP,
         default = False,
     )
     return parser.parse_args()
@@ -374,9 +361,9 @@ if __name__ == '__main__':
         )
 
     try:
-        print 'Monitoring files in %s' % options.directory
-        print 'ignoring files in %s' % (options.patterns_file)
-        print 'press ^C to quit'
+        print lang.MONITORING % options.directory
+        print lang.IGNORING % (options.patterns_file)
+        print lang.QUIT
 
         timer = Timer(options.round_time)
         ui = UserInterface(timer, options.use_thread)
@@ -393,7 +380,7 @@ if __name__ == '__main__':
         gtk.main()
 
     except KeyboardInterrupt:
-        print '\nleaving...'
+        print lang.LEAVING
         if options.use_thread:
             ui.thread.stop()
         sys.exit(0)

--- a/lang.py
+++ b/lang.py
@@ -36,7 +36,9 @@ PATTERNS_HELP = 'Defines the file with patterns to ignore. '
 TIME_HELP = 'Define the time of each round'
 ARDUINO_HELP = 'If this flag is used an interface with Arduino will be used'
 MULTITHREAD_HELP = 'If this flag is used the program will run in a thread'
-
+BEFORE_HELP = ('Run this command before running tests.'
+               'WARNING: It will not run in thread, so be careful with your commands'
+)
 MONITORING = 'Monitoring files in %s'
 IGNORING = 'ignoring files in %s'
 QUIT = 'press ^C to quit'

--- a/lang.py
+++ b/lang.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+SET_TIME = 'Alterar tempo (%d segs)'
+RESET_TIME = 'Resetar tempo'
+NO_RUNNING = u"Nenhum projeto em execução"
+PAUSE = 'Pausar'
+START = 'Reproduzir'
+TIME_IS_UP = 'Your time is up!'
+WRITE_TIME = 'Escolha o tempo (em segundos)!'
+VALUE_ERROR = u"Caracter inválido. Suas alterações não foram salvas"
+
+KILL = "Matar %s"
+
+ARDUINO_ERROR = u'Algum erro de comunicação com o Arduino ocorreu!'
+
+INTERRUPTED_EXECUTION = u"Execução interrompida"
+
+PATTERNS_NOT_FOUND = 'Could not find %s. Patterns will not be ignored\n' 
+
+PYNOTIFY_IMPORT_ERROR1 = '\n\n*** Could not import pynotify. '
+PYNOTIFY_IMPORT_ERROR2 = ('Make sure it is installed so you '
+                          'can see the notifications ***\n\n\n')
+
+GIT_ERROR1 = 'Impossible to commit to repository. '
+GIT_ERROR2 = 'Make sure git is installed and this is a valid repository'
+
+DESCRIPTION = """
+    %prog watches a directory for changes. As soon as there are any changes
+    to the files being watched, it runs the commands specified as positional
+    arguments. You can specify as many commands as you wish, but don't forget
+    to use quotes if you command has spaces in it.
+""".replace('  ', '')
+GIT_HELP = ('if this flag is used, a git commit will '
+            'be issued whenever the files change')
+DIRECTORY_HELP = 'Watch DIRECTORY'
+PATTERNS_HELP = 'Defines the file with patterns to ignore. '
+TIME_HELP = 'Define the time of each round'
+ARDUINO_HELP = 'If this flag is used an interface with Arduino will be used'
+MULTITHREAD_HELP = 'If this flag is used the program will run in a thread'
+
+MONITORING = 'Monitoring files in %s'
+IGNORING = 'ignoring files in %s'
+QUIT = 'press ^C to quit'
+
+LEAVING = '\nleaving...'

--- a/ui.py
+++ b/ui.py
@@ -61,11 +61,8 @@ class UserInterface(object):
     def _create_menu(self):
         self.menu = gtk.Menu()
 
-        self.pause_item = gtk.ImageMenuItem(gtk.STOCK_MEDIA_PAUSE)
-        self.pause_item.connect('activate', self.pause_timer)
-
-        self.play_item = gtk.ImageMenuItem(gtk.STOCK_MEDIA_PLAY)
-        self.play_item.connect('activate', self.start_timer)
+        self.timer_item = gtk.ImageMenuItem(gtk.STOCK_MEDIA_PAUSE)
+        self.timer_item.connect('activate', self.timer_button)
 
         self.quit_item = gtk.ImageMenuItem(gtk.STOCK_QUIT)
         self.quit_item.connect('activate', self.main_quit, gtk)
@@ -80,8 +77,7 @@ class UserInterface(object):
 
             self.menu.append(self.kill_item)
             self.menu.append(self.separator2)
-        self.menu.append(self.pause_item)
-        self.menu.append(self.play_item)
+        self.menu.append(self.timer_item)
         self.menu.append(self.separator)
         self.menu.append(self.quit_item)
         
@@ -107,13 +103,23 @@ class UserInterface(object):
         self.thread.stop()
 
 
-    def pause_timer(self, widget=None):
-        self.status_icon.set_from_stock(gtk.STOCK_MEDIA_PAUSE)
-        self.timer.pause()
+    def timer_button(self, widget=None):
+        if self.timer.running:
+            self.pause_timer()
+        else:
+            self.start_timer()
 
     def start_timer(self, widget=None):
         self._set_icon()
         self.timer.start()
+        self.timer_item.set_label("Pausar")
+    
+    def pause_timer(self, widget=None):
+        self.status_icon.set_from_stock(gtk.STOCK_MEDIA_PAUSE)
+        self.timer.pause()
+        self.timer_item.set_label("Reproduzir")
+        
+    
 
     def warn_time_is_up(self):
         """Shows a dialog warning the pilot that his time is up"""
@@ -177,8 +183,10 @@ class UserInterface(object):
             )
             self.status_icon.set_tooltip(time_str)
         else:
+            self.timer_item.set_sensitive(False)
             self.pause_timer()
             self.warn_time_is_up()
+            self.timer_item.set_sensitive(True)
             self.start_timer()
-
+            
         return True

--- a/ui.py
+++ b/ui.py
@@ -38,7 +38,7 @@ PASS_ICON = os.path.join(IMAGE_DIR, 'green_belt.png')
 FAIL_ICON = os.path.join(IMAGE_DIR, 'red_belt.png')
 
 __all__ = ['UserInterface']
-
+        
 class UserInterface(object):
 
     def __init__(self, timer, use_thread):
@@ -52,8 +52,6 @@ class UserInterface(object):
         self._create_menu()
         self.status_icon.set_visible(True)
         
-        
-
         self.start_timer()
 
         gobject.timeout_add(1000, self.update_timer)
@@ -67,6 +65,10 @@ class UserInterface(object):
         self.quit_item = gtk.ImageMenuItem(gtk.STOCK_QUIT)
         self.quit_item.connect('activate', self.main_quit, gtk)
 
+        self.set_time_item = gtk.MenuItem('Alterar tempo')
+        self.set_time_item.connect('activate', self.set_time)
+
+    
         self.separator = gtk.MenuItem()
         
         if self.use_thread:
@@ -78,6 +80,7 @@ class UserInterface(object):
             self.menu.append(self.kill_item)
             self.menu.append(self.separator2)
         self.menu.append(self.timer_item)
+        self.menu.append(self.set_time_item)
         self.menu.append(self.separator)
         self.menu.append(self.quit_item)
         
@@ -94,6 +97,19 @@ class UserInterface(object):
             PASS_ICON if self.current_status == 0 else FAIL_ICON
         )
         
+    def set_time(self, widget=None):
+        self.timer_item.set_sensitive(False)
+        
+        if self.timer.running:
+            self.pause_timer()
+            self.warn_set_time()
+            self.timer_item.set_sensitive(True)
+            self.start_timer()
+        else:
+            self.warn_set_time()
+            
+          
+        
     def main_quit(self, arg, widget=None):
         if self.use_thread:
             self.thread.stop()
@@ -104,10 +120,8 @@ class UserInterface(object):
 
 
     def timer_button(self, widget=None):
-        if self.timer.running:
-            self.pause_timer()
-        else:
-            self.start_timer()
+        self.pause_timer() if self.timer.running else self.start_timer()
+
 
     def start_timer(self, widget=None):
         self._set_icon()
@@ -130,7 +144,27 @@ class UserInterface(object):
         dialog.show_all()
         dialog.run()
         dialog.destroy()
+        
+    def warn_set_time(self):
+        """Shows a dialog warning the pilot that his time is up"""
+        dialog = gtk.Dialog('Dojotools', buttons=(gtk.STOCK_OK, 0))
+  
+        dialog.set_default_size(180, 120)
+        dialog.set_keep_above(True)
+        dialog.vbox.pack_start(gtk.Label('Escolha o tempo (em segundos)!'))
+        entrada = gtk.Entry(15)
+        
+        entrada.set_text(str(self.timer.round_time))
+        dialog.vbox.add(entrada)
+        dialog.show_all()
+        dialog.run()
+        try:
+            self.timer.round_time = int(entrada.get_text())
+        except:
+            pass
 
+        dialog.destroy()
+        
 
     def html_escape(self, text):
         """Produce entities within text."""		 

--- a/ui.py
+++ b/ui.py
@@ -65,7 +65,7 @@ class UserInterface(object):
         self.quit_item = gtk.ImageMenuItem(gtk.STOCK_QUIT)
         self.quit_item.connect('activate', self.main_quit, gtk)
 
-        self.set_time_item = gtk.MenuItem('Alterar tempo')
+        self.set_time_item = gtk.MenuItem('Alterar tempo (%d segs)' % (self.timer.round_time))
         self.set_time_item.connect('activate', self.set_time)
         
         self.reset_time_item = gtk.MenuItem('Resetar tempo')
@@ -95,10 +95,18 @@ class UserInterface(object):
         data.show_all()
         data.popup(None, None, None, button, time)
 
+    def _timer_items_set_sensitive(self, value):
+        self.timer_item.set_sensitive(value)
+        self.reset_time_item.set_sensitive(value)
+
     def _set_icon(self):
         self.status_icon.set_from_file(
             PASS_ICON if self.current_status == 0 else FAIL_ICON
         )
+        
+    def set_kill_label(self, label=u"Nenhum projeto em execução"):
+        self.kill_item.set_sensitive(not label == u"Nenhum projeto em execução")
+        self.kill_item.set_label(label)
         
     def set_time(self, widget=None):
         self.timer_item.set_sensitive(False)
@@ -164,6 +172,7 @@ class UserInterface(object):
         dialog.run()
         try:
             self.timer.round_time = int(entrada.get_text())
+            self.set_time_item.set_label('Alterar tempo (%d segs)' % (self.timer.round_time))
         except:
             pass
 
@@ -211,7 +220,7 @@ class UserInterface(object):
                 pynotify.URGENCY_NORMAL if status == 0
                 else pynotify.URGENCY_CRITICAL
             )
-            message.show()
+            message.show() 
 
     def update_timer(self):
         if self.timer.time_left:
@@ -221,10 +230,10 @@ class UserInterface(object):
             )
             self.status_icon.set_tooltip(time_str)
         else:
-            self.timer_item.set_sensitive(False)
             self.pause_timer()
+            self._timer_items_set_sensitive(False)
             self.warn_time_is_up()
-            self.timer_item.set_sensitive(True)
+            self._timer_items_set_sensitive(True)
             self.start_timer()
             
         return True

--- a/ui.py
+++ b/ui.py
@@ -67,8 +67,10 @@ class UserInterface(object):
 
         self.set_time_item = gtk.MenuItem('Alterar tempo')
         self.set_time_item.connect('activate', self.set_time)
-
-    
+        
+        self.reset_time_item = gtk.MenuItem('Resetar tempo')
+        self.reset_time_item.connect('activate', self.reset_time)
+        
         self.separator = gtk.MenuItem()
         
         if self.use_thread:
@@ -81,6 +83,7 @@ class UserInterface(object):
             self.menu.append(self.separator2)
         self.menu.append(self.timer_item)
         self.menu.append(self.set_time_item)
+        self.menu.append(self.reset_time_item)
         self.menu.append(self.separator)
         self.menu.append(self.quit_item)
         
@@ -108,7 +111,8 @@ class UserInterface(object):
         else:
             self.warn_set_time()
             
-          
+    def reset_time(self, widget=None):
+        self.timer.time_left = self.timer.round_time 
         
     def main_quit(self, arg, widget=None):
         if self.use_thread:

--- a/ui.py
+++ b/ui.py
@@ -41,14 +41,18 @@ __all__ = ['UserInterface']
 
 class UserInterface(object):
 
-    def __init__(self, timer):
+    def __init__(self, timer, use_thread):
         self.timer = timer
+        self.thread = None
+        self.use_thread = use_thread
         self.current_status = 0
 
         self.status_icon = gtk.StatusIcon()
         self.status_icon.set_from_file(PASS_ICON)
         self._create_menu()
         self.status_icon.set_visible(True)
+        
+        
 
         self.start_timer()
 
@@ -64,14 +68,24 @@ class UserInterface(object):
         self.play_item.connect('activate', self.start_timer)
 
         self.quit_item = gtk.ImageMenuItem(gtk.STOCK_QUIT)
-        self.quit_item.connect('activate', gtk.main_quit, gtk)
+        self.quit_item.connect('activate', self.main_quit, gtk)
 
         self.separator = gtk.MenuItem()
+        
+        if self.use_thread:
+            self.separator2 = gtk.MenuItem()
+            
+            self.kill_item = gtk.MenuItem(u"Nenhum projeto em execução")
+            self.kill_item.connect('activate', self.kill_process)
 
+            self.menu.append(self.kill_item)
+            self.menu.append(self.separator2)
         self.menu.append(self.pause_item)
         self.menu.append(self.play_item)
         self.menu.append(self.separator)
         self.menu.append(self.quit_item)
+        
+
 
         self.status_icon.connect('popup-menu', self._show_menu, self.menu)
 
@@ -83,6 +97,15 @@ class UserInterface(object):
         self.status_icon.set_from_file(
             PASS_ICON if self.current_status == 0 else FAIL_ICON
         )
+        
+    def main_quit(self, arg, widget=None):
+        if self.use_thread:
+            self.thread.stop()
+        gtk.main_quit(arg)
+        
+    def kill_process(self, widget=None):
+        self.thread.stop()
+
 
     def pause_timer(self, widget=None):
         self.status_icon.set_from_stock(gtk.STOCK_MEDIA_PAUSE)


### PR DESCRIPTION
Como caimos em loop infinito em 3 dos 4 dojos que participei nesta semana (ontem, quarta, não teve, ninguem apareceu para participar) e o dojotools acabou quebrando nelas, resolvi pegar para fazer alterações:

-Coloquei os comandos principais de execução rodando em uma thread. Assim, o dojotools não morre quando entra em loop infinito (É necessário usar a opção -m)

-Juntei os botões de pausar e reproduzir em um único com as duas funções

-Fiz um botão para alterar o tempo da rodada (não precisa mais matar o dojotools, alterar por linha de comando e abrir denovo)

-Fiz um botão para resetar o tempo atual

-Separei textos em um arquivo lang.py, pois vi que as mensagens de texto estavam misturando ingles com português (Eu não resolvi isso, apenas separei o arquivo)

-Coloquei uma opção -b para executar programas sem aparecer a notificação e a mensagem no terminal. Assim dá para usar o clear, sem ficar com caracteres bugados do "clear;[comando]",  ou mesmo compilar algum arquivo e depois mandar os testes executarem
